### PR TITLE
added error message and fixed spelling of 'traveling'

### DIFF
--- a/src/main/resources/static/script.js
+++ b/src/main/resources/static/script.js
@@ -106,5 +106,5 @@ function calculateAndDisplayRoute(directionsService, directionsRenderer) {
     .then((response) => {
         directionsRenderer.setDirections(response);
     })
-        .catch((e) => window.alert("Directions request failed due to " + status));
+        .catch((e) => window.alert("Sorry, we could not calculate driving directions for these locations. Please try a different location.");
 }

--- a/src/main/resources/templates/planATrip.html
+++ b/src/main/resources/templates/planATrip.html
@@ -23,7 +23,7 @@
 
         <div>
             <label> Destination:
-                <input type="text" id="destinationInput" placeholder="travelling to...">
+                <input type="text" id="destinationInput" placeholder="traveling to...">
             </label>
         </div>
 
@@ -33,8 +33,6 @@
     </div>
 
     <div id="map"></div>
-
-
 
 
 


### PR DESCRIPTION
We tried different versions and settled on this generic error message that displays when users select a location with a Lat/Lng that is incompatible with Google Maps. (Confirmed, this is a Google Maps issue.)